### PR TITLE
Fix the server to account for slack's timeout policy by adding background tasks.

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 # FastAPI server entry
 import os
 from dotenv import load_dotenv
-from fastapi import FastAPI, HTTPException, Request, Form
+from fastapi import BackgroundTasks, FastAPI, HTTPException, Request, Form
 from fastapi.responses import JSONResponse, PlainTextResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
@@ -50,16 +50,33 @@ async def challenge(request: Request):
 
 # For PR links
 @app.post("/slack/summarizepr")
-async def handle_summarizepr(request: Request, text: str = Form(...)):
+async def handle_summarizepr(
+    request: Request,
+    text: str = Form(...),
+    response_url: str = Form(...),  # Provided by Slack.
+    background_tasks: BackgroundTasks = BackgroundTasks(),
+):
     # Ensure valid GitHub PR link
     if "github.com" not in text or "/pull/" not in text:
         return PlainTextResponse(
             "Please provide a valid GitHub PR link.", status_code=200
         )
 
-    # Basic for now, extract info from PR link.
+    # Queue summary work in a background task
+    background_tasks.add_task(process_pr_summary, text, response_url)
+
+    # Return an immediate response to respect slack's timeout rule
+    immediate_resp = (
+        "🔄 Analyzing PR... This may take a moment. I'll update you shortly!"
+    )
+
+    return PlainTextResponse(immediate_resp, status_code=200)
+
+
+async def process_pr_summary(pr_url: str, response_url: str):
+    """Background task to process PR and send result back to Slack"""
     try:
-        parts = text.split("/")
+        parts = pr_url.split("/")
         owner, repo, pr_number = parts[3], parts[4], parts[6]
 
         github_token = os.getenv("GITHUB_TOKEN")
@@ -67,7 +84,7 @@ async def handle_summarizepr(request: Request, text: str = Form(...)):
         if github_token:
             headers["Authorization"] = f"token {github_token}"
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=30.0) as client:
             # Fetch PR data
             github_api_url = (
                 f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}"
@@ -87,17 +104,15 @@ async def handle_summarizepr(request: Request, text: str = Form(...)):
             author = pr_data["user"]["login"]
             state = pr_data["state"]
             html_url = pr_data["html_url"]
-
-            # Files changed count
-            files_changed = pr_data.get("changed_files", 0)
+            files_changed = pr_data.get("changed_files", 0)  # Files changed count
             additions = pr_data.get("additions", 0)
             deletions = pr_data.get("deletions", 0)
 
-            print(f"PR Title: {title}")
-            print(f"PR Description: {description}")
-            print(f"Files changed: {files_changed}")
-            print(f"Additions: +{additions}, Deletions: -{deletions}")
-            print(f"Diff content length: {len(diff_content)} characters")
+            # print(f"PR Title: {title}")
+            # print(f"PR Description: {description}")
+            # print(f"Files changed: {files_changed}")
+            # print(f"Additions: +{additions}, Deletions: -{deletions}")
+            # print(f"Diff content length: {len(diff_content)} characters")
 
             # Use OpenAI to summarize the PR
             summarizer = PRSummarizer()
@@ -113,7 +128,24 @@ async def handle_summarizepr(request: Request, text: str = Form(...)):
             response_text += f"📂 **Status:** {state}\n\n"
             response_text += summary
 
+            # Send the response text back to slack using the response url
+            await send_to_slack_response_url(response_url, response_text)
+
             return PlainTextResponse(response_text, status_code=200)
 
     except Exception as e:
-        return PlainTextResponse(f"Error parsing PR link: {str(e)}", status_code=200)
+        error_msg = f"❌ Error analyzing PR: {str(e)}"
+        await send_to_slack_response_url(response_url, error_msg)
+
+
+async def send_to_slack_response_url(response_url: str, response_text: str):
+    # Send delated response back to slack
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            payload = {
+                "text": response_text,
+                "response_type": "in_channel",  # or "ephemeral" for private
+            }
+            await client.post(response_url, json=payload)
+    except Exception as e:
+        print(f"Failed to send response to Slack: {e}")


### PR DESCRIPTION
Previously, everything tried to work in one go, but slack does not allow operations to take long. Thus,to resolve this issue I implemented background tasks so slack gets a quick response while the work is being done elsewhere, then directed to the slack channel.